### PR TITLE
불필요한 매도로직수정

### DIFF
--- a/FE/apis/login.ts
+++ b/FE/apis/login.ts
@@ -21,7 +21,7 @@ const loginAPI = {
 		}
 	},
 	checkAccessToken: async () => {
-		const accessToken = localStorage.getItem('accessToken'),
+		const accessToken: any = localStorage.getItem('accessToken'),
 			email = localStorage.getItem('email'),
 			refreshToken = localStorage.getItem('refreshToken');
 		// const expiredTime: any = localStorage.getItem('expiredTime');


### PR DESCRIPTION
8시 50분 50초 ~ 9시 정각에 매도 로직 동작시

현재 가격이 목표 가격에 비해 큰 경우 매도하자마자 매수를 하는 현상이 발생하여

불필요한 수수료를 지불하는 상황이 발생하였습니다.

이를 방지하기 위해 현재 가격이 목표 가격보다 높을시에는 매도를 하지 않는 로직으로 수정하였습니다.